### PR TITLE
Restore nuget packages with dependency errors

### DIFF
--- a/Infra.CrossCutting/Infra.CrossCutting.csproj
+++ b/Infra.CrossCutting/Infra.CrossCutting.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.1.2" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
   </ItemGroup>

--- a/Infra.Ioc/Infra.Ioc.csproj
+++ b/Infra.Ioc/Infra.Ioc.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/RGRTRASPORTE/RGRTRASPORTE.csproj
+++ b/RGRTRASPORTE/RGRTRASPORTE.csproj
@@ -18,7 +18,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.11" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Serilog and Serilog.AspNetCore package versions to resolve a NU1605 package downgrade error.

The build failed because `Serilog.AspNetCore 9.0.0` required `Serilog >= 4.2.0`, but `Infra.Ioc.csproj` and `Infra.CrossCutting.csproj` explicitly referenced an older `Serilog 3.1.1`. This PR updates `Serilog` to `4.2.0` in those projects and aligns `Serilog.AspNetCore` to `9.0.0` in `RGRTRASPORTE.csproj` for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-abdb347d-434f-47ee-89b6-2f3edf492dd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-abdb347d-434f-47ee-89b6-2f3edf492dd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

